### PR TITLE
Apply go modernize fixes

### DIFF
--- a/cmd/tpmk/args.go
+++ b/cmd/tpmk/args.go
@@ -44,7 +44,7 @@ func parseOptionsMap(opt []string) map[string]string {
 func parseKeyAttributes(s string) (tpm2.KeyProp, error) {
 	var keyProp tpm2.KeyProp
 	s = strings.Replace(s, " ", "", -1)
-	for _, prop := range strings.Split(s, "|") {
+	for prop := range strings.SplitSeq(s, "|") {
 		v, ok := stringToKeyAttribute[prop]
 		if !ok {
 			return keyProp, fmt.Errorf("unknown attribute property '%s'", prop)
@@ -61,7 +61,7 @@ func parseKeyAttributes(s string) (tpm2.KeyProp, error) {
 func parseNVAttributes(s string) (tpm2.NVAttr, error) {
 	var nvAttr tpm2.NVAttr
 	s = strings.Replace(s, " ", "", -1)
-	for _, prop := range strings.Split(s, "|") {
+	for prop := range strings.SplitSeq(s, "|") {
 		v, ok := stringToNVAttribute[prop]
 		if !ok {
 			return nvAttr, fmt.Errorf("unknown attribute '%s'", prop)

--- a/device_other.go
+++ b/device_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package tpmk
 

--- a/device_windows.go
+++ b/device_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package tpmk
 

--- a/nv.go
+++ b/nv.go
@@ -41,10 +41,7 @@ func NVWrite(dev io.ReadWriteCloser, index tpmutil.Handle, b []byte, password st
 	// Can only write maxBuffer bytes at a time so need to batch up the writes until everything is written
 	var offset uint16
 	for len(b) > 0 {
-		length := len(b)
-		if length > maxBuffer {
-			length = maxBuffer
-		}
+		length := min(len(b), maxBuffer)
 		if err := tpm2.NVWrite(dev, tpm2.HandleOwner, tpmutil.Handle(index), password, b[:length], offset); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- Use `min()` builtin instead of manual if/assign pattern in `nv.go`
- Remove redundant `// +build` constraint lines in `device_other.go` and `device_windows.go` (`//go:build` suffices since Go 1.17+)
- Use `strings.SplitSeq` in range loops in `cmd/tpmk/args.go` for efficiency