### PR TITLE
Fix typos and update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# tmpk - TPM2 key and storage management toolkit
+# tpmk - TPM2 key and storage management toolkit
 
-[![GoDoc](https://godoc.org/github.com/folbricht/tpmk?status.svg)](https://godoc.org/github.com/folbricht/tpmk)
+[![Go Reference](https://pkg.go.dev/badge/github.com/folbricht/tpmk.svg)](https://pkg.go.dev/github.com/folbricht/tpmk)
+[![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 This toolkit strives to simplify common tasks around key and certificates involving TPM2. It also provides the tools necessary to make use of keys in the module for TLS connections and OpenPGP in Go. It does not attempt to provide a feature-rich interface to support all possible use-cases and features. tpmk consists of a Go library and a tool with a simple interface. It currently provides:
 
@@ -64,7 +65,7 @@ go get -u github.com/folbricht/tpmk/cmd/tpmk
 
 ### RSA key generation and certificate storage in NV
 
-In this example, the goal is to have an RSA key generated in the TPM, and have a signed certificate for the key stored in NV in the TPM. This allows a machine to retain a signed key+certificate without relying on disk storage. While the generated keys doesn't leave the module, the CA to sign it is expected to be available as files at time of signing.
+In this example, the goal is to have an RSA key generated in the TPM, and have a signed certificate for the key stored in NV in the TPM. This allows a machine to retain a signed key+certificate without relying on disk storage. While the generated key doesn't leave the module, the CA to sign it is expected to be available as files at time of signing.
 
 Generate the key in the TPM and write the public key (in PEM format) to disk.
 
@@ -92,7 +93,7 @@ tpmk key generate 0x81000000 - | tpmk x509 generate -c ca.crt -k ca.key --out-fo
 
 ### Establishing a mutual TLS connection using a TPM key
 
-Here the goal is to use a key from the TPM to establish a mutual TLS connection with a server. The key is assumed to have been generated already (see prior example). While not strictly neccessary, the signed x509 is kept in NV as well.
+Here the goal is to use a key from the TPM to establish a mutual TLS connection with a server. The key is assumed to have been generated already (see prior example). While not strictly necessary, the signed x509 is kept in NV as well.
 
 Start off with some setup. Defining the handle/index that hold the key and certificate and open the TPM.
 

--- a/cmd/tpmk/args.go
+++ b/cmd/tpmk/args.go
@@ -39,7 +39,7 @@ func parseOptionsMap(opt []string) map[string]string {
 }
 
 // Parses a string of key properties as specified in the command line and returns
-// the propery value. For example "sign|fixedtpm|fixedparent" becomes
+// the property value. For example "sign|fixedtpm|fixedparent" becomes
 // tpm2.FlagSign | tpm2.FlagFixedTPM | tpm2.FlagFixedParent.
 func parseKeyAttributes(s string) (tpm2.KeyProp, error) {
 	var keyProp tpm2.KeyProp
@@ -56,7 +56,7 @@ func parseKeyAttributes(s string) (tpm2.KeyProp, error) {
 }
 
 // Parses a string of NV properties as specified in the command line and returns
-// the propery value. For example "ownerwrite|ownerread|authread|ppread" becomes
+// the property value. For example "ownerwrite|ownerread|authread|ppread" becomes
 // tpm2.AttrOwnerWrite | tpm2.AttrOwnerRead | tpm2.AttrAuthRead | tpm2.AttrPPRead.
 func parseNVAttributes(s string) (tpm2.NVAttr, error) {
 	var nvAttr tpm2.NVAttr

--- a/cmd/tpmk/keyimport.go
+++ b/cmd/tpmk/keyimport.go
@@ -17,7 +17,7 @@ func newKeyImportCommand() *cobra.Command {
 		Use:   "import <handle> <private-key>",
 		Short: "Import an existing key",
 		Long: `Import a key into the TPM. The key should be
-in PEM-encode PKCS#1 format.
+in PEM-encoded PKCS#1 format.
 
 Use '-' to read the key from STDIN.`,
 		Example: `  tpmk key import 0x81000000 private.pem`,

--- a/cmd/tpmk/nvrm.go
+++ b/cmd/tpmk/nvrm.go
@@ -17,9 +17,7 @@ func newNVRmCommand() *cobra.Command {
 		Use:   "rm <index>",
 		Short: "Delete an NV index",
 		Long: `Delete data in an NV index and make the index available
-again.
-
-Use '-' to print the data to STDOUT.`,
+again.`,
 		Example: `  tpmk nv rm 0x1500000`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/tpmk/openpgpdecrypt.go
+++ b/cmd/tpmk/openpgpdecrypt.go
@@ -40,7 +40,7 @@ to determine if decryption was successful.
 While the public key can also be read from STDIN, it is not possible
 to read the input data from there at the same time.`,
 		Example: `  tpmk openpgp decrypt 0x81000000 pub.pgp encrypted.pgp decrypted.txt
-  tpmk openpgp decrypt -a 0x81000000 pup.pgp - -
+  tpmk openpgp decrypt -a 0x81000000 pub.pgp - -
   tpmk openpgp decrypt -a -m 0x81000000 - secret.txt.pgp -`,
 		Args: cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/tpmk/openpgpgen.go
+++ b/cmd/tpmk/openpgpgen.go
@@ -25,7 +25,7 @@ func newOpenPGPGenCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "generate <handle> <pubkeyfile>",
-		Short: "Generate an public key",
+		Short: "Generate a public key",
 		Long: `Generate an OpenPGP public key using an existing private key in the TPM.
 The key must already be present and be an RSA key. The generated public
 key will contain one identity which must be provided with -n and -e.

--- a/cmd/tpmk/openpgpsign.go
+++ b/cmd/tpmk/openpgpsign.go
@@ -37,10 +37,9 @@ By default a detached signature is produced. Use --clear-sign to
 generate a clear text signature instead.
 
 While the public key can also be read from STDIN, it is not possible
-to read the input data from there at
-the same time.`,
+to read the input data from there at the same time.`,
 		Example: `  tpmk openpgp sign 0x81000000 pub.pgp input.txt input.sig
-  tpmk openpgp sign -a 0x81000000 pup.pgp - -
+  tpmk openpgp sign -a 0x81000000 pub.pgp - -
   tpmk openpgp sign -c -m 0x81000000 public.gpg input.txt input.txt.asc
   tpmk openpgp sign -a -m 0x81000000 - input.txt -`,
 		Args: cobra.ExactArgs(4),

--- a/cmd/tpmk/sshcert.go
+++ b/cmd/tpmk/sshcert.go
@@ -33,7 +33,7 @@ func newSSHCertCommand() *cobra.Command {
 		Long: `Generate an SSH certificate using the provided public key and
 sign it with a CA key.
 
-The certificat format can be 'openssh' or 'wire' which is smaller
+The certificate format can be 'openssh' or 'wire' which is smaller
 and more suitable for storage in NV indexes.
 
 Use '-' to read the key from STDIN, or to output the certificate 

--- a/cmd/tpmk/sshclient.go
+++ b/cmd/tpmk/sshclient.go
@@ -38,13 +38,13 @@ and reads/writes to it via STDIN/STDOUT. Supports host and
 client certificates, with the client certificate optionally
 read from an NV index in the TPM as well.
 
-Unless -k is used, a know hosts file in OpenSSH format needs
+Unless -k is used, a known hosts file in OpenSSH format needs
 to be provided with --known-hosts/-s. If none is given in the
 command line, $HOME/.ssh/known_hosts will be used if available
 followed by /etc/ssh/ssh_known_hosts.
 
 Note that no assumptions are made regarding user or port. Both
-need to be speficied in the command in the typical format:
+need to be specified in the command in the typical format:
 <user>@<host>:<port>
 `,
 		Example: `  tpmk ssh client 0x81000000 root@host:22 "ls -l"
@@ -110,7 +110,7 @@ func runSSHClient(opt sshClientOptions, args []string) error {
 		return errors.Wrap(err, "invalid key")
 	}
 
-	// Use client certificate, if provided to extend the ssh.Signer with a cerfificate
+	// Use client certificate, if provided to extend the ssh.Signer with a certificate
 	if opt.crtFile != "" || opt.crtHandle != "" {
 		var b []byte
 		var err error
@@ -130,7 +130,7 @@ func runSSHClient(opt sshClientOptions, args []string) error {
 			}
 		}
 
-		// Unmarshall the certificate according to the provided format
+		// Unmarshal the certificate according to the provided format
 		var pub ssh.PublicKey
 		switch opt.crtFormat {
 		case "openssh":
@@ -158,7 +158,7 @@ func runSSHClient(opt sshClientOptions, args []string) error {
 	}
 
 	// Find a known_hosts file with valid host keys or certificates. Use the following search order:
-	// 1. Proviced by command line options
+	// 1. Provided by command line options
 	// 2. Disabled via command line (-k)
 	// 3. $HOME/.ssh/known_hosts if $HOME is non-empty
 	// 4. /etc/ssh/ssh_known_hosts

--- a/cmd/tpmk/sshpub.go
+++ b/cmd/tpmk/sshpub.go
@@ -66,7 +66,7 @@ func runSSHPub(opt sshPubOptions, args []string) error {
 		return errors.Wrap(err, "read public key")
 	}
 
-	// Write the certificate to file or STDOUT
+	// Write the public key to file or STDOUT
 	b := tpmk.MarshalOpenSSHPublic(sshPublic, "")
 	if outKeyfile == "-" {
 		_, err = os.Stdout.Write(b)

--- a/device.go
+++ b/device.go
@@ -9,7 +9,7 @@ import (
 
 // SimDev is used for testing. When set, calling OpenDevice("sim") will return it instead
 // of trying to connect to a simulator. Used in command tests that first setup an internal
-// simltor, set SimDev, then call the command with "sim" as device name.
+// simulator, set SimDev, then call the command with "sim" as device name.
 var SimDev io.ReadWriteCloser
 
 // OpenDevice opens a TPM2. If device is 'sim', it'll connect to a simulator on localhost:2321.
@@ -42,7 +42,7 @@ func (s Simulator) Close() error {
 	return s.Conn.Close()
 }
 
-// OpenSim opens a connection to a local TPM2 simulator via TCP and initalizes it by calling Startup.
+// OpenSim opens a connection to a local TPM2 simulator via TCP and initializes it by calling Startup.
 func OpenSim() (Simulator, error) {
 	dev, err := mssim.Open(mssim.Config{CommandAddress: "localhost:2321", PlatformAddress: "localhost:2322"})
 	if err != nil {

--- a/tls_test.go
+++ b/tls_test.go
@@ -225,7 +225,7 @@ func TestDecrypt(t *testing.T) {
 			case *rsa.OAEPOptions:
 				// The TPM only uses null-terminated labels, and those are included in the calculations.
 				// We need to do the same for the results to match, even though the null isn't really
-				// needed in the Go library for the same caluclations.
+				// needed in the Go library for the same calculations.
 				label := opts.Label
 				if len(label) > 0 {
 					label = append(label, 0)


### PR DESCRIPTION
## Summary

- Fix spelling and grammar errors across README, command descriptions, and code comments
- Update Go reference badge from deprecated godoc.org to pkg.go.dev
- Add BSD 3-Clause license badge
- Remove incorrect "Use '-' to print data to STDOUT" from `nv rm` help text
- Fix incorrect comment in `sshpub.go` referring to "certificate" instead of "public key"