### PR TITLE
Fix Windows build, ignored flags/parameters, and wrong EvictControl password

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    name: Build (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: Linux
+            os: ubuntu-latest
+          - name: Windows
+            os: windows-latest
+    env:
+      # Only the TPM simulator used in tests needs cgo, the tool itself is pure Go
+      CGO_ENABLED: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+
+  test:
+    name: Test (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Test
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # tpmk - TPM2 key and storage management toolkit
 
+[![Build](https://github.com/folbricht/tpmk/actions/workflows/build.yml/badge.svg)](https://github.com/folbricht/tpmk/actions/workflows/build.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/folbricht/tpmk.svg)](https://pkg.go.dev/github.com/folbricht/tpmk)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 

--- a/cmd/tpmk/sshcert.go
+++ b/cmd/tpmk/sshcert.go
@@ -104,6 +104,7 @@ func runSSHCert(opt sshCertOptions, args []string) error {
 		Key:         sshPublic,
 		CertType:    ssh.UserCert,
 		KeyId:       opt.id,
+		Serial:      opt.serial,
 		ValidAfter:  0, // 0 - MaxUint64 = "forever"
 		ValidBefore: math.MaxUint64,
 		Permissions: ssh.Permissions{

--- a/cmd/tpmk/sshclient.go
+++ b/cmd/tpmk/sshclient.go
@@ -119,7 +119,7 @@ func runSSHClient(opt sshClientOptions, args []string) error {
 			if err != nil {
 				return err
 			}
-			b, err = tpmk.NVRead(dev, crtHandle, "")
+			b, err = tpmk.NVRead(dev, crtHandle, opt.crtPassword)
 			if err != nil {
 				return errors.Wrap(err, "reading crt from TPM")
 			}

--- a/device_windows.go
+++ b/device_windows.go
@@ -5,7 +5,7 @@ package tpmk
 import (
 	"io"
 
-	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/legacy/tpm2"
 )
 
 // openImpl opens the TPM on Windows

--- a/key.go
+++ b/key.go
@@ -14,6 +14,7 @@ import (
 )
 
 // GenRSAPrimaryKey generates a primary RSA key and makes it persistent under the given handle.
+// parentPW is the password of the owner hierarchy, ownerPW becomes the password of the new key.
 func GenRSAPrimaryKey(dev io.ReadWriteCloser, handle tpmutil.Handle, parentPW, ownerPW string, attr tpm2.KeyProp) (crypto.PublicKey, error) {
 	// Define the TPM key template
 	pub := tpm2.Public{
@@ -37,13 +38,14 @@ func GenRSAPrimaryKey(dev io.ReadWriteCloser, handle tpmutil.Handle, parentPW, o
 	}
 	defer tpm2.FlushContext(dev, signerHandle)
 
-	// Make the key persistent
-	return pubKey, tpm2.EvictControl(dev, ownerPW, tpm2.HandleOwner, signerHandle, handle)
+	// Make the key persistent. EvictControl is authorized by the owner
+	// hierarchy password, not the password of the new key.
+	return pubKey, tpm2.EvictControl(dev, parentPW, tpm2.HandleOwner, signerHandle, handle)
 }
 
 // LoadExternal loads an existing key-pair into the TPM and returns the key handle. The key is loaded
-// / into the Null hierarchy and not persistent.
-func LoadExternal(dev io.ReadWriteCloser, handle tpmutil.Handle, pk crypto.PrivateKey, password string, attr tpm2.KeyProp) (tpmutil.Handle, error) {
+// into the Null hierarchy and not persistent. The password becomes the auth value of the loaded key.
+func LoadExternal(dev io.ReadWriteCloser, pk crypto.PrivateKey, password string, attr tpm2.KeyProp) (tpmutil.Handle, error) {
 	var (
 		tpm2Pub  tpm2.Public
 		tpm2Priv tpm2.Private
@@ -66,6 +68,7 @@ func LoadExternal(dev io.ReadWriteCloser, handle tpmutil.Handle, pk crypto.Priva
 		}
 		tpm2Priv = tpm2.Private{
 			Type:      tpm2.AlgRSA,
+			AuthValue: []byte(password),
 			Sensitive: private.Primes[0].Bytes(),
 		}
 	case *ecdsa.PrivateKey:
@@ -87,6 +90,7 @@ func LoadExternal(dev io.ReadWriteCloser, handle tpmutil.Handle, pk crypto.Priva
 		}
 		tpm2Priv = tpm2.Private{
 			Type:      tpm2.AlgECC,
+			AuthValue: []byte(password),
 			Sensitive: private.D.Bytes(),
 		}
 	default:

--- a/nv.go
+++ b/nv.go
@@ -32,7 +32,7 @@ func NVWrite(dev io.ReadWriteCloser, index tpmutil.Handle, b []byte, password st
 		password,
 		password,
 		nil,
-		tpm2.AttrOwnerWrite|tpm2.AttrOwnerRead|tpm2.AttrAuthRead|tpm2.AttrPPRead,
+		attr,
 		uint16(len(b)),
 	); err != nil {
 		return err


### PR DESCRIPTION
Fixes several bugs found while auditing the code:

- **Windows build was broken**: `device_windows.go` imported `github.com/google/go-tpm/tpm2` (the new TPMDirect API, which has no `OpenTPM`) instead of `legacy/tpm2` used everywhere else. `GOOS=windows go build` failed with `undefined: tpm2.OpenTPM`.
- **`NVWrite` ignored its `attr` parameter**: NV space was always defined with hardcoded `ownerwrite|ownerread|authread|ppread` attributes, silently discarding whatever the caller (and `tpmk nv write -a`) requested.
- **`tpmk ssh client --crt-password` was ignored**: the client certificate was always read from the NV index with an empty password, so password-protected indexes could never be used.
- **`tpmk ssh certificate --serial` was ignored**: `Serial` was never set on the certificate, so all certs were issued with serial 0, which also breaks serial-based revocation.
- **`GenRSAPrimaryKey` used the wrong password for `EvictControl`**: it passed `ownerPW` (the new key's auth value) where the owner hierarchy password (`parentPW`) is required. This only worked when both passwords were identical, as is the case in the CLI.
- **`LoadExternal` ignored its `handle` and `password` parameters**: the handle parameter is unusable since external keys are loaded into the Null hierarchy at a TPM-assigned handle, so it is removed; the password is now applied as the auth value of the loaded key.

Verified with `go build` for linux/windows/darwin, `go vet`, and `go test ./...`.