### PR TITLE
Harden NV writes, OpenPGP entity reading, and output file handling

### DIFF
--- a/cmd/tpmk/keygen.go
+++ b/cmd/tpmk/keygen.go
@@ -89,5 +89,5 @@ func runKeyGen(opt keygenOptions, args []string) error {
 		_, err = os.Stdout.Write(pem)
 		return err
 	}
-	return ioutil.WriteFile(output, pem, 0755)
+	return ioutil.WriteFile(output, pem, 0644)
 }

--- a/cmd/tpmk/keyread.go
+++ b/cmd/tpmk/keyread.go
@@ -64,5 +64,5 @@ func runKeyRead(opt keyReadOptions, args []string) error {
 		_, err = os.Stdout.Write(pem)
 		return err
 	}
-	return ioutil.WriteFile(output, pem, 0755)
+	return ioutil.WriteFile(output, pem, 0644)
 }

--- a/cmd/tpmk/nvread.go
+++ b/cmd/tpmk/nvread.go
@@ -61,5 +61,5 @@ func runNVRead(opt nvReadOptions, args []string) error {
 		_, err = os.Stdout.Write(b)
 		return err
 	}
-	return ioutil.WriteFile(output, b, 0755)
+	return ioutil.WriteFile(output, b, 0644)
 }

--- a/cmd/tpmk/sshcert.go
+++ b/cmd/tpmk/sshcert.go
@@ -137,5 +137,5 @@ func runSSHCert(opt sshCertOptions, args []string) error {
 		_, err = os.Stdout.Write(b)
 		return err
 	}
-	return ioutil.WriteFile(crtfile, b, 0755)
+	return ioutil.WriteFile(crtfile, b, 0644)
 }

--- a/cmd/tpmk/sshpub.go
+++ b/cmd/tpmk/sshpub.go
@@ -72,5 +72,5 @@ func runSSHPub(opt sshPubOptions, args []string) error {
 		_, err = os.Stdout.Write(b)
 		return err
 	}
-	return ioutil.WriteFile(outKeyfile, b, 0755)
+	return ioutil.WriteFile(outKeyfile, b, 0644)
 }

--- a/cmd/tpmk/x509gen.go
+++ b/cmd/tpmk/x509gen.go
@@ -94,10 +94,11 @@ func runx509Gen(opt x509GenOptions, args []string) error {
 
 	// Build the x509 cert template
 	template := x509.Certificate{
-		NotBefore:    time.Now(),
-		NotAfter:     expiry,
-		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		SerialNumber: big.NewInt(opt.serial),
+		NotBefore:             time.Now(),
+		NotAfter:              expiry,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		SerialNumber:          big.NewInt(opt.serial),
+		BasicConstraintsValid: true,
 	}
 	if opt.commonName != "" {
 		template.Subject = pkix.Name{CommonName: opt.commonName}
@@ -137,5 +138,5 @@ func runx509Gen(opt x509GenOptions, args []string) error {
 		_, err = os.Stdout.Write(b)
 		return err
 	}
-	return ioutil.WriteFile(crtfile, b, 0755)
+	return ioutil.WriteFile(crtfile, b, 0644)
 }

--- a/handle.go
+++ b/handle.go
@@ -26,7 +26,7 @@ func GetHandles(dev io.ReadWriteCloser, start tpm2.TPMProp) ([]tpmutil.Handle, e
 			}
 			handles = append(handles, h)
 		}
-		if !more {
+		if !more || len(cap) == 0 {
 			break
 		}
 		pos = uint32(cap[len(cap)-1].(tpmutil.Handle)) + 1

--- a/nv.go
+++ b/nv.go
@@ -2,7 +2,9 @@ package tpmk
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"math"
 
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
@@ -11,6 +13,11 @@ import (
 // NVWrite reserves space in an NV index and writes to it starting at offset 0. It automatically
 // determines the max buffer size prior to writing blocks to the index.
 func NVWrite(dev io.ReadWriteCloser, index tpmutil.Handle, b []byte, password string, attr tpm2.NVAttr) error {
+	// The size of an NV index is a uint16, reject anything larger before it wraps around
+	if len(b) > math.MaxUint16 {
+		return fmt.Errorf("data too large for NV index: %d bytes, max %d", len(b), math.MaxUint16)
+	}
+
 	// Determine MAX_NV_BUFFER_SIZE from the TPM capabilities. Needed to batch writes to NV storage.
 	cap, _, err := tpm2.GetCapability(dev, tpm2.CapabilityTPMProperties, 1, uint32(tpm2.NVMaxBufferSize))
 	if err != nil {

--- a/openpgp.go
+++ b/openpgp.go
@@ -101,8 +101,12 @@ func ReadOpenPGPEntity(packets *packet.Reader, signer crypto.Signer) (*openpgp.E
 	e.PrivateKey = privateKey
 	for i := range e.Subkeys {
 		if e.Subkeys[i].PublicKey.KeyId == privateKey.KeyId {
-			e.Subkeys[i].PrivateKey = privateKey
-			e.Subkeys[i].PrivateKey.IsSubkey = true
+			// Build a separate private key for the subkey rather than reusing the
+			// primary's. Setting IsSubkey on a shared instance would mark the
+			// primary private key as a subkey as well.
+			subPrivateKey := packet.NewSignerPrivateKey(e.Subkeys[i].PublicKey.CreationTime, signer)
+			subPrivateKey.IsSubkey = true
+			e.Subkeys[i].PrivateKey = subPrivateKey
 		}
 	}
 	return e, nil


### PR DESCRIPTION
Follow-up to #25 with fixes for the more minor findings from the same audit (stacked on #25 since both touch `nv.go`; GitHub will retarget this to master when #25 merges):

- **`NVWrite` silently truncated sizes over 64KB**: `uint16(len(b))` wrapped around for larger inputs, defining an NV index of the wrong size and failing confusingly mid-write. Now returns a clear error.
- **`ReadOpenPGPEntity` aliased one `*packet.PrivateKey` as both primary and subkey**: setting `IsSubkey = true` on the shared instance marked the primary private key as a subkey as well. Subkeys now get their own instance, created with the subkey's creation time so its key ID stays consistent.
- **`GetHandles` could panic** on an empty capability page with the more-flag set.
- **Output files were written with mode 0755**: keys, certificates, and NV data were world-readable and executable. Now written with 0644.
- **`tpmk x509 generate` claimed `CertSign` key usage on every issued certificate**: leaf certificates no longer assert CA-ish key usage, and basic constraints are included marking them as non-CA.