### PR TITLE
Add GitHub Actions CI with Linux tests and Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,24 +6,16 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: Test (Linux)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - name: Build
-        run: go build ./...
-      - name: Vet
-        run: go vet ./...
-      - name: Test
-        run: go test ./...
-
-  build-windows:
-    name: Build (Windows)
-    runs-on: windows-latest
+  build:
+    name: Build (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: Linux
+            os: ubuntu-latest
+          - name: Windows
+            os: windows-latest
     env:
       # Only the TPM simulator used in tests needs cgo, the tool itself is pure Go
       CGO_ENABLED: "0"
@@ -36,3 +28,14 @@ jobs:
         run: go build ./...
       - name: Vet
         run: go vet ./...
+
+  test:
+    name: Test (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    name: Test (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...
+
+  build-windows:
+    name: Build (Windows)
+    runs-on: windows-latest
+    env:
+      # Only the TPM simulator used in tests needs cgo, the tool itself is pure Go
+      CGO_ENABLED: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # tpmk - TPM2 key and storage management toolkit
 
+[![Build](https://github.com/folbricht/tpmk/actions/workflows/build.yml/badge.svg)](https://github.com/folbricht/tpmk/actions/workflows/build.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/folbricht/tpmk.svg)](https://pkg.go.dev/github.com/folbricht/tpmk)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 


### PR DESCRIPTION
Adds a GitHub Actions workflow since the repo currently has no CI:

- **Test (Linux)**: `go build`, `go vet`, and `go test ./...` on ubuntu-latest. The test suite runs against the built-in TPM simulator from go-tpm-tools, which needs cgo/OpenSSL and is available on the Linux runners.
- **Build (Windows)**: `go build` and `go vet` on windows-latest with `CGO_ENABLED=0` (only the test simulator needs cgo). This would have caught the broken Windows build fixed in #25.

The Go version is taken from go.mod. Also adds a build status badge to the README.

Stacked on #25 because the Windows build only compiles with that fix; GitHub will retarget this to master when #25 merges.